### PR TITLE
Changed theme toggle to sun/moon slider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "http-server": "^14.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.5.0",
         "react-scripts": "5.0.1",
         "uuid": "^9.0.1",
         "web-vitals": "^2.1.4"
@@ -15544,6 +15545,15 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -30150,6 +30160,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "http-server": "^14.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.5.0",
     "react-scripts": "5.0.1",
     "uuid": "^9.0.1",
     "web-vitals": "^2.1.4"

--- a/src/App.css
+++ b/src/App.css
@@ -49,6 +49,7 @@ html, body {
   background-color: var(--bg-color);
   display: grid;
   grid-template-columns: auto auto 7em;
+  align-items: center;
   color: var(--opposite-header-color);
   margin-bottom: .25em;
 }
@@ -73,19 +74,71 @@ a {
   color: var(--link-color);
 }
 
-.theme-toggle {
-  background: #6c6c6c;
-  border: none;
-  padding: .45rem;
-  border-radius: 2em;
-  margin-top: 2.5em;
-  color: var(--bg-color);
-  height: fit-content;
-  width: fit-content;
+/* Theme Toggle Slider */
+.theme-switch-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1em;
 }
 
-.theme-toggle:hover {
-  background: #939393;
+.theme-switch {
+  display: inline-block;
+  height: 34px;
+  position: relative;
+  width: 60px;
+}
+
+.theme-switch input {
+  display: none;
+}
+
+.slider {
+  background-color: #6c6c6c;
+  bottom: 0;
+  cursor: pointer;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: .4s;
+  border-radius: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  padding: 0 5px;
+}
+
+.slider:before {
+  background-color: #fff;
+  bottom: 4px;
+  content: "";
+  height: 26px;
+  left: 4px;
+  position: absolute;
+  transition: .4s;
+  width: 26px;
+  border-radius: 50%;
+  z-index: 2;
+}
+
+input:checked + .slider:before {
+  transform: translateX(26px);
+}
+
+.slider .icon {
+  font-size: 18px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+}
+
+.slider .sun {
+  color: #f1c40f;
+}
+
+.slider .moon {
+  color: #f1c40f;
 }
 
 @media screen and (max-width: 1280px) {
@@ -98,14 +151,9 @@ a {
     margin-right: 5%;
   }
 
-  .theme-toggle {
-    display: flex;
-    margin: auto;
-    align-content: center;
-    margin-bottom: .25em;
-    justify-content: center;
-    width: 10em;
-}
+  .theme-switch-wrapper {
+    margin: 1em auto;
+  }
 }
 @media screen and (max-width: 650px) {
   .left-align-mobile {

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import ProjectsContainer from './components/containers/ProjectsContainer';
 import SkillsContainer from './components/containers/SkillsContainer';
 
 import React, { Component } from 'react'
+import { FaSun, FaMoon } from 'react-icons/fa';
 
 export default class App extends Component {
   constructor(props) {
@@ -57,7 +58,15 @@ export default class App extends Component {
         <header className="App-header">
           <TitleComponent/>
           <NavContainer/>
-          <button className='theme-toggle' onClick={this.toggleTheme}>Toggle Theme</button>
+          <div className="theme-switch-wrapper">
+            <label className="theme-switch" htmlFor="checkbox">
+              <input type="checkbox" id="checkbox" onChange={this.toggleTheme} checked={this.state.darkMode} />
+              <div className="slider">
+                <FaMoon className="icon moon" />
+                <FaSun className="icon sun" />
+              </div>
+            </label>
+          </div>
         </header>
         <AboutContainer/>
         <div id="skills"></div>


### PR DESCRIPTION
This pull request updates the theme toggle in the application, replacing the basic button with a modern slider switch featuring sun and moon icons. It also improves the layout and alignment of elements in the UI.

**Theme Toggle Redesign:**

* Replaced the old `.theme-toggle` button with a custom slider switch using a new `.theme-switch` component, including sun and moon icons from `react-icons` for better user experience. (`src/App.js`, `src/App.css`, [[1]](diffhunk://#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67L60-R69) [[2]](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972L76-R141)
* Added the `react-icons` package as a new dependency in `package.json` to support the new icons.

**UI and Layout Improvements:**

* Improved alignment of elements in the main layout by centering grid items in the `html, body` CSS rule.
* Updated responsive styles for the new theme switcher to ensure proper spacing and alignment across different screen sizes.

**Code Updates:**

* Imported `FaSun` and `FaMoon` icons from `react-icons/fa` in `src/App.js` to use in the theme switch component.